### PR TITLE
Replaced rust-crypto and rustc-serialize dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "oath2"
 version = "0.9.1"
 authors = ["Andrei Vacariu <andrei@avacariu.me>", "crypto-universe <ykp@protonmail.ch>"]
@@ -14,6 +13,8 @@ keywords = ["oath", "totp", "hotp", "ocra"]
 categories = ["cryptography"]
 
 [dependencies]
-rust-crypto = "^0.2.34"
-rustc-serialize = "^0.3.16"
-time = "^0.1.34"
+sha-1 = "0.3"
+sha2 = "0.5"
+digest = "0.5"
+hmac = "0.1"
+rustc-hex = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oath2"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Andrei Vacariu <andrei@avacariu.me>", "crypto-universe <ykp@protonmail.ch>"]
 license = "MIT"
 description = """

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ functions.
 
 ### Misc
 
-If you don't want to use `rustc-serialize` directly, this library provides a
-wrapper around `from_hex()`. This helps with the functions that expect byte
+If you don't want to use other crates for hex conversion, this library provides a
+convinience function `from_hex()`. This helps with the functions that expect byte
 arrays.
 
     let seed = oath::from_hex("ff").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub enum HashType {
     SHA512
 }
 
-/// This library provides a wrapper around `rustc_serialize::hex::from_hex()`.
+/// This library provides a wrapper around `rustc_hex::from_hex()`.
 /// This helps with the functions that expect byte arrays.
 ///
 /// # Examples
@@ -140,6 +140,7 @@ pub fn hotp(key: &str, counter: u64, digits: u32) -> Result<u64, &str> {
 }
 
 /// Low-level function, that computes an one-time password using TOTP algorithm.
+/// It's generic over hashing algorithm `D`.
 ///
 /// `key` is a slice, that represents the shared secret;
 ///
@@ -150,8 +151,6 @@ pub fn hotp(key: &str, counter: u64, digits: u32) -> Result<u64, &str> {
 /// `time_step` - time step in seconds (default value is 30);
 ///
 /// `current_time` - current Unix time (in seconds);
-///
-/// `hash` is a hashing algorithm. Can be Sha1, Sha256, Sha512;
 ///
 /// # Example
 ///


### PR DESCRIPTION
`rust-crypto` seems to be abandoned and crates from RustCrypto offer a smaller footprint, plus they are written in completely pure Rust.

`rustc-serialize` deprecated and can be easily replaced by `rustc-hex` crate. (or by `hex`, but it will require more changes)

BTW is there a particular reason for creating a separate crate and not sending a PR to the @avacariu's repository?

UPD: Ah, I found an [answer](https://github.com/avacariu/rust-oath/pull/4) to my question. Maybe he could grant you an access to the `oath` crate or even transfer the repository?